### PR TITLE
Add GitHub Pages blog

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,5 +38,7 @@
 			}
 		}
 	},
-	"postStartCommand": "vale sync"
+	"postStartCommand": "vale sync",
+	"postCreateCommand": "gem install jekyll bundler",
+	"runArgs": ["-p", "4000:4000"]
 }

--- a/README.md
+++ b/README.md
@@ -13,3 +13,127 @@ Subscribe and follow our GitHub Pages to get notified when new articles are publ
 
 ### Social Media Sharing
 Share our articles on BlueSky, LinkedIn, X, and other platforms using the social media sharing buttons on each blog post.
+
+## Enabling GitHub Pages
+
+To enable GitHub Pages in the repository settings, follow these steps:
+
+* Go to the repository on GitHub.
+* Click on the "Settings" tab.
+* Scroll down to the "Pages" section in the left sidebar.
+* Under "Source", select the branch you want to use for GitHub Pages (e.g., `main`).
+* Click "Save" to apply the changes.
+* Optionally, configure a custom domain if you have one.
+* Your site will be published at `https://<username>.github.io/<repository-name>/`.
+
+## Structuring the `_posts` Directory
+
+To structure the `_posts` directory for your blog, follow these steps:
+
+* Create a `_posts` directory in the root of your repository.
+* Inside the `_posts` directory, create Markdown files (`.md`) for each blog post.
+* Name each Markdown file using the format `YYYY-MM-DD-title.md`, where `YYYY-MM-DD` is the date of the post and `title` is a short, descriptive title for the post.
+* At the beginning of each Markdown file, include front matter in YAML format to provide metadata for the post. The front matter should include at least the following fields:
+  * `title`: The title of the blog post.
+  * `date`: The publication date of the blog post in `YYYY-MM-DD` format.
+  * `author`: The author of the blog post.
+  * `tags`: A list of tags associated with the blog post.
+* Write the content of the blog post in Markdown format after the front matter.
+
+Example structure:
+```
+_posts/
+  2023-09-01-welcome-to-our-blog.md
+  2023-09-02-another-interesting-post.md
+```
+
+Example front matter for a blog post:
+```yaml
+---
+title: "Welcome to Our Blog"
+date: 2023-09-01
+author: "John Doe"
+tags: ["introduction", "welcome"]
+---
+```
+
+## Using Jekyll for GitHub Pages
+
+To use Jekyll for GitHub Pages, follow these steps:
+
+* Install Jekyll on your local machine by following the instructions on the Jekyll website.
+* Create a new Jekyll site by running `jekyll new myblog` in your terminal. This will generate a new Jekyll site in a directory called `myblog`.
+* Navigate to the `myblog` directory and start the Jekyll server by running `bundle exec jekyll serve`. This will start a local server at `http://localhost:4000` where you can preview your site.
+* Customize your Jekyll site by editing the files in the `myblog` directory. You can modify the `_config.yml` file to configure various settings for your site, such as the title, description, and theme.
+* Add your blog posts to the `_posts` directory in the `myblog` directory. Each post should be a Markdown file with a filename in the format `YYYY-MM-DD-title.md`.
+* Once you are satisfied with your Jekyll site, push the contents of the `myblog` directory to your GitHub repository.
+* Enable GitHub Pages in the repository settings by following the steps mentioned earlier.
+* Your Jekyll site will be published at `https://<username>.github.io/<repository-name>/`.
+
+## Using Liquid Templates in Jekyll
+
+To use Liquid templates in Jekyll, follow these steps:
+
+* Liquid is a templating language used in Jekyll to create dynamic content. It allows you to use variables, filters, and logic in your templates.
+* In your Jekyll site, you can use Liquid in your HTML files, Markdown files, and `_layouts` files.
+* To use Liquid in your templates, enclose your Liquid code in `{% %}` for tags and `{{ }}` for output.
+
+### Basic usage
+
+* Use `{{ variable }}` to output the value of a variable.
+* Use `{% if condition %} ... {% endif %}` to add conditional logic.
+* Use `{% for item in collection %} ... {% endfor %}` to loop through a collection.
+* Use filters to modify the output of variables, e.g., `{{ variable | filter }}`.
+
+### Example
+
+* Create a `_layouts` directory in the root of your repository.
+* Add a `default.html` file in the `_layouts` directory to define the default layout for your site.
+* Use Liquid tags and output in the `default.html` file to create a dynamic layout.
+
+Example `default.html`:
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ page.title }}</title>
+</head>
+<body>
+  <header>
+    <h1>{{ site.title }}</h1>
+  </header>
+  <main>
+    {{ content }}
+  </main>
+  <footer>
+    <p>&copy; {{ site.time | date: "%Y" }} {{ site.author }}</p>
+  </footer>
+</body>
+</html>
+```
+
+### Using Liquid in posts
+
+* In your `_posts` directory, you can use Liquid to add dynamic content to your blog posts.
+* Use front matter to define variables for each post, and use Liquid to output these variables in your post templates.
+
+Example front matter in a post:
+```yaml
+---
+title: "My First Post"
+date: 2023-09-01
+author: "John Doe"
+---
+```
+
+Example post content:
+```markdown
+# {{ page.title }}
+
+Published on {{ page.date | date: "%B %d, %Y" }} by {{ page.author }}
+
+Welcome to my first blog post!
+```
+
+By using Liquid templates in Jekyll, you can create dynamic and customizable content for your GitHub Pages blog. For more detailed information, refer to the Liquid documentation.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,6 @@
+theme: jekyll-theme-hacker
+title: "GitHub Lowlands Community Blog"
+description: "A blog for the GitHub Lowlands Community"
+author:
+  name: "GitHub Lowlands Community"
+  email: "contact@githublowlandscommunity.com"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ page.title }}</title>
+</head>
+<body>
+  <header>
+    <h1>{{ site.title }}</h1>
+  </header>
+  <main>
+    {{ content }}
+  </main>
+  <footer>
+    <p>&copy; {{ site.time | date: "%Y" }} {{ site.author }}</p>
+  </footer>
+</body>
+</html>

--- a/_posts/2023-09-01-welcome-to-our-blog.md
+++ b/_posts/2023-09-01-welcome-to-our-blog.md
@@ -1,0 +1,12 @@
+---
+title: "Welcome to Our Blog"
+date: 2023-09-01
+author: "John Doe"
+tags: ["introduction", "welcome"]
+---
+
+# Welcome to Our Blog
+
+Welcome to the GitHub Lowlands Community Blog! This is our first post, and we are excited to share our thoughts, ideas, and updates with you. Stay tuned for more interesting content and feel free to share your feedback with us.
+
+Thank you for being a part of our community!

--- a/_posts/2023-09-02-another-interesting-post.md
+++ b/_posts/2023-09-02-another-interesting-post.md
@@ -1,0 +1,12 @@
+---
+title: "Another Interesting Post"
+date: 2023-09-02
+author: "Jane Smith"
+tags: ["interesting", "update"]
+---
+
+# Another Interesting Post
+
+This is another interesting post on the GitHub Lowlands Community Blog. We are excited to share more updates and insights with you. Stay tuned for more content and feel free to share your thoughts with us.
+
+Thank you for being a part of our community!

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Blog Posts</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Blog Posts</h1>
+  </header>
+  <main>
+    {% for post in site.posts %}
+      <article>
+        <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        <p>Published on {{ post.date | date: "%B %d, %Y" }} by {{ post.author }}</p>
+        <div class="post-content">
+          {{ post.excerpt }}
+        </div>
+        <!-- AddThis Social Media Sharing Buttons -->
+        <div class="addthis_inline_share_toolbox"></div>
+        <script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-5f8b8b8b8b8b8b8b"></script>
+      </article>
+    {% endfor %}
+  </main>
+  <footer>
+    <p>&copy; 2023 GitHub Lowlands Community</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>GitHub Lowlands Community Blog</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Welcome to the GitHub Lowlands Community Blog</h1>
+  </header>
+  <main>
+    <p>This is the homepage of the GitHub Lowlands Community Blog. Here you will find the latest updates, articles, and news from our community.</p>
+    <p><a href="blog.html">Visit our blog page</a> to read our latest posts.</p>
+  </main>
+  <footer>
+    <p>&copy; 2023 GitHub Lowlands Community</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
Add GitHub Pages support for the blog.

* **README.md**: Add instructions for enabling GitHub Pages, structuring the `_posts` directory, using Jekyll for GitHub Pages, and using Liquid templates in Jekyll.
* **_config.yml**: Add configuration file with theme, title, description, and author information.
* **index.html**: Create a basic homepage for the blog with a link to the blog page.
* **blog.html**: Create a page to list blog posts using Liquid templates and add social media sharing buttons.
* **_posts/2023-09-01-welcome-to-our-blog.md**: Add a blog post with front matter and content.
* **_posts/2023-09-02-another-interesting-post.md**: Add another blog post with front matter and content.
* **_layouts/default.html**: Create a default layout for the site using Liquid templates.
* **.devcontainer/devcontainer.json**: Add instructions for installing Jekyll and starting the Jekyll server.

